### PR TITLE
Fix rulebook URLs to point to barge.org.

### DIFF
--- a/src/colophon.md
+++ b/src/colophon.md
@@ -3,8 +3,8 @@ Colophon
 
 This book is available in one of three ways:
 
-* Web: [https://ts4z.github.io/barge-rulebook](https://ts4z.github.io/barge-rulebook)
-* PDF: (location TBD)
+* Web: [https://www.barge.org/rulebook/](https://www.barge.org/rulebook/)
+* PDF: [https://www.barge.org/rulebook.pdf](https://www.barge.org/rulebook.pdf)
 * Source: [https://github.com/ts4z/barge-rulebook](https://github.com/ts4z/barge-rulebook)
 
 This document is written in Markdown, with a tool called
@@ -12,10 +12,11 @@ This document is written in Markdown, with a tool called
 navigate.  mdbook produces a pretty good printed copy.
 
 A GitHub workflow is used to build the rulebook into this version hosted in
-GitHub pages (at the web link above).
+GitHub pages (at the web link above), and another one publishes it to
+[https://www.barge.org/](barge.org).
 
 The "dead tree PDF edition" of the rulebook, intended for paper and to be used
 at a poker table, is produced via a perl script that extracts the file list
 from the mdbook configuration, uses CommonMark (a Markdown library) to produce
 LaTeX, then doctors that up with a perl script.  All of the pieces are either
-free software or included at with the rest of the source code above.
+common free software or included with the other pieces above.

--- a/src/preface.md
+++ b/src/preface.md
@@ -21,12 +21,12 @@ This version of the rulebook is provided in both a web page and a LaTeX-based
 PDF book which is better for printing.
 
 The web version represents the full book.  Currently, it is continually updated
-at [https://ts4z.github.io/barge-rulebook/](https://ts4z.github.io/barge-rulebook/)
+at [https://www.barge.org/rulebook/](https://www.barge.org/rulebook/)
 when there are changes.  At that site, you can print the web version of the book.
 This prints as a web page and will lack a table of contents.
 
 For printing, the PDF version is recommended.  This version is available at
-[https://ts4z.github.io/barge-rulebook.pdf](https://ts4z.github.io/barge-rulebook.pdf).
+[https://www.barge.org/rulebook.pdf](https://www.barge.org/rulebook.pdf).
 This comes with a nice table of contents and page numbers.  This version
 includes hyperlinks when viewed electronically, but it is not as easy to
 navigate as a web page or on a mobile device.  (This version may also be


### PR DESCRIPTION
Except source code, that can stay where it is.