### PR TITLE
rewords Crayfish entry.

### DIFF
--- a/src/crayfish.md
+++ b/src/crayfish.md
@@ -1,20 +1,29 @@
 ## Crayfish
 
-Crayfish provides a variant of [Hold’em](texas-holdem.md) (and
-potentially any other game that uses a five-carda board).
+Crayfish is typically dealt as a variant of Pot-Limit
+[Omaha](omaha-high-only.md), and less commonly as a variant of
+[Hold’em](texas-holdem.md) (but can potentially be a variant of any
+game that uses a five-card board).
 
-All five cards of the board are dealt on the flop.  On the turn and river, roll a die.
+All five cards of the board are dealt face up on the flop.  On the turn and river, a die is rolled. Each of the die rolls has the potential to turn a board card face down, thus removing that card from play.
 
-On a roll of 1-5, flip the corresponding card face down.  Cards are numbered
-from left to right (flop 1-3, turn 4, river 5).
+On a roll of 1-5, the corresponding card is turned face down if
+it is not already face down.  Cards are numbered from left to right. E.g.,
+on a board of 4♦ 7♥ 2♣ T♥ K♦ if a one is rolled on the die, the 4♦ would
+be turned face down; if a three is rolled, the 2♣ would be turned face down.
+When a 6 is rolled, nothing happens on that roll; the board remains the same.
 
-On a roll of 6, no cards are turned over.
-
-If the number is rolled on the turn and river, the card remains turned face down.
+At the showdown, the board will have between three and five cards:
+* three cards, if two different die rolls are made and each roll is between one and five
+* four cards, if both die rolls are the same number between one and five
+* four cards, if one of the die rolls is a six and the other is between one and five
+* five cards, if both die rolls are six
 
 Face down cards can't be used at showdown.
 
 ### Notes
+
+A crayfish swims backwards, which is how this variant got its name.
 
 BARGErs heard about Crayfish via [Don Rieck's
 appearance](https://pokerchannel.substack.com/p/binglaha?utm_source=podcast-email%2Csubstack&publication_id=368194&post_id=179987649&utm_campaign=email-play-on-substack&utm_medium=email&utm_content=play_card_show_title&r=4a3ejk&triedRedirect=true)


### PR DESCRIPTION
@ts4z: You didn't ask for this and I didn't create an issue to discuss it, so if you don't like these changes or you want to make any beyond, that's fine with me. I think mentioning that crayfish is primarily a PLO variant is kind of important, the rest are nits, but it was easier for me to do a reword than to describe each of the things that perhaps we might want to change.

The only material change is that crayfish is typically a variant of PLO, rather than Hold'em, but this commit also changes wording a bit to fix a typo, keep consistent tenses, provide an example and add redundancy in an attempt to prevent misunderstandings from a light reading of a concise description.